### PR TITLE
[UPGRADE-3.0] Starting an unquoted string with @, `, |, or > leads to a ParseException.

### DIFF
--- a/Resources/config/select2_ajax_entity_type.yml
+++ b/Resources/config/select2_ajax_entity_type.yml
@@ -4,6 +4,6 @@ parameters:
 services:
     jfdl_form.select2_ajax_entity_type:
         class: %jfdl_form.select2_ajax_entity_type.class%
-        arguments: [@doctrine, @router, @translator]
+        arguments: ['@doctrine', '@router', '@translator']
         tags:
             - { name: form.type, alias: jfdl_select2_ajax_entity}


### PR DESCRIPTION
Cfr https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#yaml