### PR TITLE
UPGRADE Symfony 3.3.x :: Not quoting the scalar "%jfdl_form.select2_a…

### DIFF
--- a/Resources/config/select2_ajax_entity_type.yml
+++ b/Resources/config/select2_ajax_entity_type.yml
@@ -3,7 +3,7 @@ parameters:
 
 services:
     jfdl_form.select2_ajax_entity_type:
-        class: %jfdl_form.select2_ajax_entity_type.class%
+        class: '%jfdl_form.select2_ajax_entity_type.class%'
         arguments: ['@doctrine', '@router', '@translator']
         tags:
             - { name: form.type, alias: jfdl_select2_ajax_entity}


### PR DESCRIPTION
Not quoting the scalar "%jfdl_form.select2_ajax_entity_type.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.